### PR TITLE
chore: Docker Image 자동 빌드를 위한 Github Action과 Dockerfile 추가

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,71 @@
+name: release
+on:
+  push:
+    branches:
+      - main
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  tagging:
+    name: 태깅 및 릴리즈
+    runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.tag_version.outputs.new_tag }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: versioning and tagging
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: releasing
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.tag_version.outputs.new_tag }}
+          name: ${{ steps.tag_version.outputs.new_tag }}
+          body: ${{ steps.tag_version.outputs.changelog }}
+
+  build-image:
+    name: 도커 이미지 빌드
+    runs-on: ubuntu-latest
+    needs: tagging
+
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Check out Repository
+        uses: actions/checkout@v4
+
+      - name: Sign in github container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha
+            type=raw,value=${{ needs.tagging.outputs.tag_name }}
+            type=raw,value=latest
+
+      - name: Build and Push Image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:19.9.0 AS builder
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install
+
+COPY . .
+RUN npm run build
+
+FROM node:19.9.0
+
+WORKDIR /app
+COPY package*.json ./
+RUN npm install --omit=dev
+
+COPY server.js ./
+COPY --from=builder /app/build ./build
+
+CMD ["node", "server.js"]


### PR DESCRIPTION
배포 환경에서 사용하기 위한 Docker Image를 자동으로 빌드하기 위해 Github Action과 Dockerfile을 추가했습니다.

Github Action은 아래와 같이 동작합니다.
- 동작 조건 : main 브랜치에 push
  1. Release 태그 생성
  2. 위 Release 태그를 기반으로 Docker Image를 빌드 및 Github Package로 push

Release 태그는 커밋 메시지를 기반으로 버전 명을 결정합니다.
- 버전 명 : v[major].[minor].[patch]
  - 버전 명 예시 : v1.2.3 (major: 1, minor: 2, patch: 3)
- 커밋 메시지 별 버전

  | Commit Prefix      | Version     |
  |:----------:|:-----------:|
  | BREAKING CHANGE | x.0.0 (major) |
  | feat | 0.x.0 (minor) |
  | fix | 0.0.x (patch) |

- 참고 자료
[Release 태그 Docs](https://github.com/mathieudutour/github-tag-action)
[Action 동작 예시 URL](https://github.com/dlsrks1021/WEB5_7_F1_FE/actions/runs/16309027343)